### PR TITLE
Fixes runtime errors by the threading subsystem when running with ITK5

### DIFF
--- a/CLI/DSCMRIAnalysis.cxx
+++ b/CLI/DSCMRIAnalysis.cxx
@@ -232,21 +232,6 @@ int DoIt( int argc, char * argv[], const T1 &, const T2 &)
     return EXIT_FAILURE;
     }
 
-  // // EchoTime
-  // float echoTime = 0.0;
-  // try 
-  //   {
-  //   echoTime = GetEchoTime(inputVectorVolume->GetMetaDataDictionary());
-  //   }
-  // catch (itk::ExceptionObject &exc)
-  //   {
-  //   itkGenericExceptionMacro(<< exc.GetDescription() 
-  //           << " Image " << InputFourDImageFileName.c_str() 
-  //           << " does not contain sufficient attributes to support algorithms.");
-  //   return EXIT_FAILURE;
-    
-  //   }
-
   // FlipAngle
   float FAValue = 0.0;
   try 

--- a/CLI/itkConcentrationToQuantitativeImageFilter.hxx
+++ b/CLI/itkConcentrationToQuantitativeImageFilter.hxx
@@ -47,6 +47,7 @@ ConcentrationToQuantitativeImageFilter<TInputImage,TMaskImage,TOutputImage>::Con
   this->Superclass::SetNthOutput(7, static_cast<TOutputImage*>(this->MakeOutput(7).GetPointer()));  // MTT
   this->Superclass::SetNthOutput(8, static_cast<TOutputImage*>(this->MakeOutput(8).GetPointer()));  // CBF
   this->Superclass::SetNthOutput(9, static_cast<VectorVolumeType*>(this->MakeOutput(9).GetPointer())); // fitted
+  this->DynamicMultiThreadingOff();
 }
 
 template< class TInputImage, class TMaskImage, class TOutputImage >

--- a/CLI/itkSignalIntensityToConcentrationImageFilter.hxx
+++ b/CLI/itkSignalIntensityToConcentrationImageFilter.hxx
@@ -15,6 +15,7 @@ SignalIntensityToConcentrationImageFilter<TInputImage, TMaskImage,
   m_RGD_relaxivity = 4.9E-3f;
   m_S0GradThresh = 15.0f;
   this->SetNumberOfRequiredInputs(1);
+  this->DynamicMultiThreadingOff();
 }
 
 template<class TInputImage, class TMaskImage, class TOutputImage>

--- a/CLI/itkSignalIntensityToS0ImageFilter.hxx
+++ b/CLI/itkSignalIntensityToS0ImageFilter.hxx
@@ -18,8 +18,8 @@ namespace itk
 template <class TInputImage, class TOutputImage>
 SignalIntensityToS0ImageFilter<TInputImage, TOutputImage>::SignalIntensityToS0ImageFilter()
 {
-  m_S0GradThresh = 15.0f;
-
+    m_S0GradThresh = 15.0f;
+    this->DynamicMultiThreadingOff();
 }
 
 template <class TInputImage, class TOutputImage>


### PR DESCRIPTION
Tested on a fresh build of Slicer 4.13.0.